### PR TITLE
fix(dts): reserve unreserved gaps between dts mappings

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mn-var-som-fulfil-lfp.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mn-var-som-fulfil-lfp.dts
@@ -42,8 +42,22 @@
 			no-map;
 		};
 
+		/* Reserve the 956KB gap between vdev0vring1 and rsc_table.
+		 * Without this, Linux can allocate into 0x40010000-0x400fefff. */
+		rpmsg_gap1: rpmsg_gap1@40010000 {
+			reg = <0 0x40010000 0 0xef000>;
+			no-map;
+		};
+
 		rsc_table: rsc-table@400ff000 {
 			reg = <0 0x400ff000 0 0x1000>;
+			no-map;
+		};
+
+		/* Reserve the 3MB gap between rsc_table and vdevbuffer.
+		 * Without this, Linux can allocate into 0x40100000-0x403fffff. */
+		rpmsg_gap2: rpmsg_gap2@40100000 {
+			reg = <0 0x40100000 0 0x300000>;
 			no-map;
 		};
 


### PR DESCRIPTION
# E1. Experiment w/ cordoning off unreserved DTB memory regions
Let's try a simple Claude change on `rover1.tan.fulfil.ai` [E1 Described here](https://docs.google.com/document/d/1vippVQwViu1jHt9OgOJiZWiOX-CjA1doaAMgESjogNg/edit?tab=t.ah5s8qaecc7n).

## 2\. DTS Changes: Making the Reserved Region Contiguous

### The Problem

The virtio/rpmsg protocol works like this: the A-core and M7 share a set of memory regions that both sides know about at compile time (the addresses are baked into the M7 firmware binary). The 5 separate DTS nodes describe those regions to Linux, so the kernel won't put page allocations there. But the gaps **between** them are not described — Linux treats those addresses as normal RAM.

The M7 firmware itself may not be limited to exactly those node boundaries. The resource table at `0x400ff000` is the pointer that the M7 firmware hands to Linux to say "here's where my rings are." If the M7 firmware implementation scans or initializes memory in a broader range (e.g., zeroing from `0x40000000` to `0x40500000` to initialize its heap or buffer pool), it tramples on whatever Linux put in the gaps.

### The Fix: Gap-Filling Nodes

The safest fix — because it requires no changes to M7 firmware addresses — is to add two `no-map` nodes that explicitly reserve the gap regions. This tells Linux: "don't put anything in these addresses either."

**Do not use a single large contiguous node replacing the existing ones** — the `imx8mn-cm7` driver references each node by phandle (`&vdevbuffer`, `&vdev0vring0`, etc.) and the addresses must match what the M7 firmware expects.

Add the following two nodes inside `reserved-memory { ... }` in `imx8mn-var-som-fulfil-lfp.dts`:

```
/* GAP 1: Reserve the 956KB between vdev0vring1 and rsc_table.
 * Without this, Linux can allocate heap/stack into 0x40010000–0x400fefff.
 * The M7 or virtio driver may scan this range during init, causing corruption.
 */
rpmsg_gap1: rpmsg_gap1@40010000 {
    reg = <0 0x40010000 0 0xef000>;
    no-map;
};

/* GAP 2: Reserve the 3MB between rsc_table and vdevbuffer.
 * Without this, Linux can allocate into 0x40100000–0x403fffff.
 * This is the largest unreserved window adjacent to the rpmsg region.
 */
rpmsg_gap2: rpmsg_gap2@40100000 {
    reg = <0 0x40100000 0 0x300000>;
    no-map;
};
```

**After this change, the full `0x40000000`–`0x40500000` range is reserved**:

```
0x40000000  vdev0vring0   32KB    no-map
0x40008000  vdev0vring1   32KB    no-map
0x40010000  rpmsg_gap1    956KB   no-map  ← NEW
0x400ff000  rsc_table      4KB    no-map
0x40100000  rpmsg_gap2      3MB   no-map  ← NEW
0x40400000  vdevbuffer      1MB   no-map (shared-dma-pool)
0x40500000  ─── normal Linux memory starts here ───
```

This is a **5MB contiguous reserved block** with no holes.

### Why Not One Big Node?

You might wonder: why not just do this?

```
/* Would break driver phandle lookups — don't do this */
rpmsg_all: rpmsg_all@40000000 {
    reg = <0 0x40000000 0 0x500000>;
    no-map;
};
```

The `imx8mn-cm7` node has:

```
memory-region = <&vdevbuffer>, <&vdev0vring0>, <&vdev0vring1>, <&m_core_reserved>, <&rsc_table>;
```

Each phandle (`&vdevbuffer` etc.) must resolve to an existing DT node. The rpmsg virtio driver uses these to get the specific physical addresses and sizes for the ring buffers and shared DMA pool. Replacing them with a single node breaks those references. The gap-filling approach avoids this entirely.